### PR TITLE
CI: Fail the build when reporting code coverage to Codecov.io fails

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,4 +63,4 @@ jobs:
           flags: main
           env_vars: OS,PYTHON
           name: codecov-umbrella
-          fail_ci_if_error: false
+          fail_ci_if_error: true


### PR DESCRIPTION
What the title says.