### PR TITLE
DynamoDB: Skip primary key columns in `SET` clause for `UPDATE` statements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Changed `UPDATE` statements from DynamoDB not to write the entire `data`
+  column. This allows defining primary keys on the sink table.
+
 ## 2024/08/14 v0.0.4
 - Added `BucketTransformation`, a minimal transformation engine
   based on JSON Pointer (RFC 6901).

--- a/tests/transform/test_dynamodb.py
+++ b/tests/transform/test_dynamodb.py
@@ -145,8 +145,7 @@ def test_decode_cdc_insert_nested():
 def test_decode_cdc_modify():
     assert (
         DynamoCDCTranslatorCrateDB(table_name="foo").to_sql(MSG_MODIFY) == 'UPDATE "foo" '
-        'SET data = \'{"humidity": 84.84, "temperature": 55.66, '
-        '"device": "bar", "timestamp": "2024-07-12T01:17:42"}\' '
+        "SET data['humidity'] = 84.84, data['temperature'] = 55.66 "
         "WHERE data['device'] = 'foo' AND data['timestamp'] = '2024-07-12T01:17:42';"
     )
 


### PR DESCRIPTION
CrateDB does not allow changing primary key columns, even when setting them to their current value.

This probably applies to other transformers as well (DMS and MongoDB).