### PR TITLE
DMS: Skip primary key columns in `SET` clauses for `UPDATE` statements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Changed `UPDATE` statements from DMS not to write the entire `data`
+  column. This allows defining primary keys on the sink table.
 
 ## 2024/08/16 v0.0.5
 - Changed `UPDATE` statements from DynamoDB not to write the entire `data`

--- a/tests/transform/test_aws_dms.py
+++ b/tests/transform/test_aws_dms.py
@@ -237,7 +237,7 @@ def test_decode_cdc_update_success(cdc):
     # Emulate an UPDATE operation.
     assert (
         cdc.to_sql(MSG_DATA_UPDATE_VALUE) == 'UPDATE "public"."foo" '
-        f"SET data = '{json.dumps(RECORD_UPDATE)}' "
+        "SET data['age'] = '33', data['attributes'] = '{\"foo\": \"bar\"}', data['name'] = 'John' "
         "WHERE data['id'] = '42';"
     )
 


### PR DESCRIPTION
CrateDB does not allow changing primary key columns, even when setting them to their current value.