### PR TITLE
DynamoDB: Wrap all values in UPDATE statements in quotes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- DynamoDB: Fixed a syntax issue with `text` data type in `UPDATE` statements
 
 ## 2024/08/16 v0.0.6
 - Changed `UPDATE` statements from DMS not to write the entire `data`

--- a/src/commons_codec/transform/dynamodb.py
+++ b/src/commons_codec/transform/dynamodb.py
@@ -139,14 +139,16 @@ class DynamoCDCTranslatorCrateDB(DynamoCDCTranslatorBase):
         {'humidity': {'N': '84.84'}, 'temperature': {'N': '55.66'}}
 
         OUT:
-        data['humidity] = 84.84, temperature = 55.66
+        data['humidity] = '84.84', temperature = '55.66'
         """
         values_clause = self.deserialize_item(keys)
 
         constraints: t.List[str] = []
         for key_name, key_value in values_clause.items():
-            constraint = f"{self.DATA_COLUMN}['{key_name}'] = {key_value}"
+            key_value = str(key_value).replace("'", "''")
+            constraint = f"{self.DATA_COLUMN}['{key_name}'] = '{key_value}'"
             constraints.append(constraint)
+
         return ", ".join(constraints)
 
     def keys_to_where(self, keys: t.Dict[str, t.Dict[str, str]]) -> str:

--- a/tests/transform/test_dynamodb.py
+++ b/tests/transform/test_dynamodb.py
@@ -68,12 +68,14 @@ MSG_MODIFY = {
             "humidity": {"N": "84.84"},
             "temperature": {"N": "55.66"},
             "device": {"S": "bar"},
+            "location": {"S": "Sydney"},
             "timestamp": {"S": "2024-07-12T01:17:42"},
         },
         "OldImage": {
             "humidity": {"N": "84.84"},
             "temperature": {"N": "42.42"},
             "device": {"S": "foo"},
+            "location": {"S": "Sydney"},
             "timestamp": {"S": "2024-07-12T01:17:42"},
         },
         "SizeBytes": 161,
@@ -145,7 +147,7 @@ def test_decode_cdc_insert_nested():
 def test_decode_cdc_modify():
     assert (
         DynamoCDCTranslatorCrateDB(table_name="foo").to_sql(MSG_MODIFY) == 'UPDATE "foo" '
-        "SET data['humidity'] = 84.84, data['temperature'] = 55.66 "
+        "SET data['humidity'] = '84.84', data['temperature'] = '55.66', data['location'] = 'Sydney' "
         "WHERE data['device'] = 'foo' AND data['timestamp'] = '2024-07-12T01:17:42';"
     )
 


### PR DESCRIPTION
In the long term, we might need to look up the original data type and decide more selectively how to pass different data types. For now, let's pass everything as a string and leave it to CrateDB to auto-cast values.

This fixes a reported issue:
```
sqlalchemy.exc.ProgrammingError: (crate.client.exceptions.ProgrammingError) ColumnUnknownException[Column tt unknown]
[SQL: UPDATE "poc" SET data['test'] = tt WHERE data['PK'] = 'pk' AND data['SK'] = 'sk';]
(Background on this error at: https://sqlalche.me/e/20/f405)
```