### PR TITLE
DynamoDB: Apply rough type evaluation and dispatching

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- DynamoDB: Apply rough type evaluation and dispatching when computing
+  values for `UPDATE` statements
 
 ## 2024/08/17 v0.0.7
 - DynamoDB: Fixed a syntax issue with `text` data type in `UPDATE` statements

--- a/src/commons_codec/transform/dynamodb.py
+++ b/src/commons_codec/transform/dynamodb.py
@@ -9,6 +9,7 @@ import typing as t
 import simplejson as json
 import toolz
 
+from commons_codec.util.data import is_container, is_number
 from commons_codec.vendor.boto3.dynamodb.types import TypeDeserializer
 
 logger = logging.getLogger(__name__)
@@ -145,8 +146,9 @@ class DynamoCDCTranslatorCrateDB(DynamoCDCTranslatorBase):
 
         constraints: t.List[str] = []
         for key_name, key_value in values_clause.items():
-            key_value = str(key_value).replace("'", "''")
-            constraint = f"{self.DATA_COLUMN}['{key_name}'] = '{key_value}'"
+            if not is_container(key_value) and not is_number(key_value):
+                key_value = "'" + str(key_value).replace("'", "''") + "'"
+            constraint = f"{self.DATA_COLUMN}['{key_name}'] = {key_value}"
             constraints.append(constraint)
 
         return ", ".join(constraints)

--- a/src/commons_codec/util/data.py
+++ b/src/commons_codec/util/data.py
@@ -30,3 +30,7 @@ def is_number(s):
         pass
 
     return False
+
+
+def is_container(value):
+    return isinstance(value, (dict, list, set))


### PR DESCRIPTION
When computing values for `UPDATE` statements, consider the data type of the value. It aims to improve GH-19 by @hammerhead.
